### PR TITLE
fix: improve russian contact title translation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -160,7 +160,7 @@ export class AppComponent {
       projectsLead: 'Продуктовые решения и инструменты для разработчиков.',
       contactTitle: 'Контакты',
       contactLead: 'Открыт к сотрудничеству, продуктовой разработке и выступлениям.',
-      contactCardTitle: 'Давайте на связи',
+      contactCardTitle: 'Свяжитесь со мной',
       contactCardText: 'Если хотите обсудить инженерное лидерство, поставку продукта или сотрудничество, буду рад пообщаться.',
       openSourceLabel: 'Открыть источник',
       telegramLabel: 'Телеграм',


### PR DESCRIPTION
## Summary
- replace the Russian contact card title with a clearer phrase: "Свяжитесь со мной"

## Verification
- npm run build