### PR TITLE
chore: add agent workflow and guardrails

### DIFF
--- a/.codex/skills/frontend-agent/SKILL.md
+++ b/.codex/skills/frontend-agent/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: frontend-agent
+description: Use this skill for Angular frontend implementation tasks, including UI changes, responsive styling, localization wiring, accessibility improvements, and small UX refactors.
+---
+
+# Frontend Agent
+
+## Purpose
+
+Deliver production-ready frontend changes in Angular with minimal regression risk.
+
+## Workflow
+
+1. Inspect impacted templates, TS, and CSS before editing.
+2. Prefer small and reversible changes.
+3. Keep styles token-driven and responsive.
+4. Preserve localization behavior and URL/state consistency.
+5. Validate with `npm run build`.
+
+## Guardrails
+
+- Avoid unnecessary structural rewrites.
+- Keep naming and file structure consistent with existing patterns.
+- Do not introduce dead CSS or unused inputs.
+- Keep comments in code English-only.

--- a/.codex/skills/qa-agent/SKILL.md
+++ b/.codex/skills/qa-agent/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: qa-agent
+description: Use this skill for validation, regression checks, test planning, and release risk assessment for Angular changes.
+---
+
+# QA Agent
+
+## Purpose
+
+Prevent regressions and provide a clear release confidence signal.
+
+## Workflow
+
+1. Verify acceptance behavior from user request.
+2. Run required checks (`npm run build` at minimum).
+3. Review changed files for edge cases and breakpoints.
+4. Report findings by severity.
+5. Document residual risks when full testing is not available.
+
+## Guardrails
+
+- Prefer concrete, reproducible findings.
+- Separate verified issues from assumptions.
+- Keep output concise and action-oriented.

--- a/.codex/skills/release-agent/SKILL.md
+++ b/.codex/skills/release-agent/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: release-agent
+description: Use this skill for branch workflow, commit discipline, PR creation, and safe merge operations under strict PR-only policy.
+---
+
+# Release Agent
+
+## Purpose
+
+Ship changes safely through branch, PR, and merge discipline.
+
+## Workflow
+
+1. Create a focused branch from `master`.
+2. Commit with clear scope and intent.
+3. Push branch and open PR to `master`.
+4. Ensure required checks pass.
+5. Merge only through PR (never direct push to `master`).
+
+## Guardrails
+
+- Do not bypass PR flow.
+- Keep commits atomic when practical.
+- Confirm branch and PR URLs in final report.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+- 
+
+## Changes
+
+- 
+
+## Validation
+
+- [ ] `npm run build`
+- [ ] Manual verification done for changed behavior
+
+## Risks
+
+- 
+
+## Rollback
+
+- Revert this PR
+
+## Agent Checklist
+
+- [ ] Frontend review completed (`frontend-agent`)
+- [ ] QA review completed (`qa-agent`)
+- [ ] Release flow respected (`release-agent`)
+- [ ] No direct push to `master`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["master"]
+  push:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Workflow
+
+This repository uses agent-oriented execution with strict PR-only delivery.
+
+## Global Rules
+
+- Never push directly to `master`.
+- Always work in a feature branch.
+- Always open a PR and merge through PR.
+- Run CI checks before merge.
+- Keep code comments in English.
+
+## Agent Routing
+
+- Use `frontend-agent` for UI/UX, Angular components, styling, localization, and accessibility.
+- Use `qa-agent` for validation, regression checks, test strategy, and release risk review.
+- Use `release-agent` for branch hygiene, commit quality, changelog discipline, and PR lifecycle.
+
+## Default Execution Order
+
+1. `frontend-agent` (implementation)
+2. `qa-agent` (verification and risk scan)
+3. `release-agent` (PR and merge flow)
+
+## PR Requirements
+
+- Scope is small and focused.
+- Build passes (`npm run build`).
+- User-facing changes are described.
+- Risks and rollback path are documented.


### PR DESCRIPTION
## Summary
- add repository-level AGENTS.md with strict PR-only workflow
- add project skills for frontend, QA, and release operations
- add PR template with validation and agent checklist
- add CI workflow running build on PR and master

## Verification
- npm run build