### PR TITLE
chore: enforce agent message prefix and PR approval policy

### DIFF
--- a/.codex/skills/frontend-agent/SKILL.md
+++ b/.codex/skills/frontend-agent/SKILL.md
@@ -23,3 +23,4 @@ Deliver production-ready frontend changes in Angular with minimal regression ris
 - Keep naming and file structure consistent with existing patterns.
 - Do not introduce dead CSS or unused inputs.
 - Keep comments in code English-only.
+- Prefix every agent-authored message with `[frontend-agent]`.

--- a/.codex/skills/qa-agent/SKILL.md
+++ b/.codex/skills/qa-agent/SKILL.md
@@ -22,3 +22,4 @@ Prevent regressions and provide a clear release confidence signal.
 - Prefer concrete, reproducible findings.
 - Separate verified issues from assumptions.
 - Keep output concise and action-oriented.
+- Prefix every agent-authored message with `[qa-agent]`.

--- a/.codex/skills/release-agent/SKILL.md
+++ b/.codex/skills/release-agent/SKILL.md
@@ -20,5 +20,8 @@ Ship changes safely through branch, PR, and merge discipline.
 ## Guardrails
 
 - Do not bypass PR flow.
+- Do not open PRs without explicit user approval in the current thread.
+- Do not merge PRs without explicit user approval in the current thread.
 - Keep commits atomic when practical.
 - Confirm branch and PR URLs in final report.
+- Prefix every agent-authored message with `[release-agent]`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,6 @@
 - [ ] Frontend review completed (`frontend-agent`)
 - [ ] QA review completed (`qa-agent`)
 - [ ] Release flow respected (`release-agent`)
+- [ ] Explicit user approval received for PR creation
+- [ ] Explicit user approval received for PR merge
 - [ ] No direct push to `master`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ This repository uses agent-oriented execution with strict PR-only delivery.
 
 - Never push directly to `master`.
 - Always work in a feature branch.
-- Always open a PR and merge through PR.
+- Always use PR flow for `master` updates.
+- Do not create PRs without explicit user approval in the current thread.
+- Do not merge PRs without explicit user approval in the current thread.
 - Run CI checks before merge.
 - Keep code comments in English.
+- Prefix every agent-authored message with `[agentName]`.
 
 ## Agent Routing
 


### PR DESCRIPTION
## Summary
- require `[agentName]` prefix for agent-authored messages
- require explicit user approval for PR creation and PR merge
- update agent skills and PR template checklist accordingly

## Verification
- documentation-only update