### PR TITLE
feat: add GitHub summary card section

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -132,6 +132,31 @@
   gap: 0.85rem;
 }
 
+.github-section {
+  gap: 0.7rem;
+}
+
+.github-card-link {
+  display: block;
+  text-decoration: none;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.github-card-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
+}
+
+.github-card-image {
+  width: 100%;
+  display: block;
+}
+
 @media (max-width: 640px) {
   .hero-intro {
     grid-template-columns: 1fr;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,6 +22,22 @@
     </div>
   </section>
 
+  <section class="section github-section" id="github">
+    <div class="section-head">
+      <h2>{{ t.githubTitle }}</h2>
+      <p>{{ t.githubLead }}</p>
+    </div>
+    <a
+      class="github-card-link"
+      [href]="githubProfileUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      [attr.aria-label]="t.githubOpenProfile"
+    >
+      <img class="github-card-image" [src]="githubSummaryUrl" alt="GitHub profile details for developman2013" />
+    </a>
+  </section>
+
   <section id="materials" class="section">
     <div class="section-head">
       <h2>{{ t.materialsTitle }}</h2>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,6 +30,9 @@ type AppCopy = {
   materialsLead: string;
   projectsTitle: string;
   projectsLead: string;
+  githubTitle: string;
+  githubLead: string;
+  githubOpenProfile: string;
   contactTitle: string;
   contactLead: string;
   contactCardTitle: string;
@@ -49,6 +52,9 @@ type AppCopy = {
 })
 export class AppComponent {
   readonly name = 'Mikhail Pirahouski';
+  readonly githubSummaryUrl =
+    'https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=developman2013&theme=nord_dark';
+  readonly githubProfileUrl = 'https://github.com/developman2013';
   currentLang: Lang = this.detectLangFromUrl();
   currentTheme: Theme = this.detectTheme();
 
@@ -69,6 +75,9 @@ export class AppComponent {
       materialsLead: 'Selected publications on automation and engineering productivity.',
       projectsTitle: 'Code & Projects',
       projectsLead: 'Production-facing products and developer tooling.',
+      githubTitle: 'GitHub Profile Snapshot',
+      githubLead: 'Live activity summary generated from my GitHub profile.',
+      githubOpenProfile: 'Open GitHub profile',
       contactTitle: 'Contact',
       contactLead: 'Open for collaboration, product engineering and speaking opportunities.',
       contactCardTitle: 'Let\'s talk',
@@ -158,6 +167,9 @@ export class AppComponent {
       materialsLead: 'Выбранные публикации про автоматизацию и инженерную эффективность.',
       projectsTitle: 'Код и проекты',
       projectsLead: 'Продуктовые решения и инструменты для разработчиков.',
+      githubTitle: 'Сводка GitHub профиля',
+      githubLead: 'Актуальная карточка активности, собранная на основе моего GitHub профиля.',
+      githubOpenProfile: 'Открыть GitHub профиль',
       contactTitle: 'Контакты',
       contactLead: 'Открыт к сотрудничеству, продуктовой разработке и выступлениям.',
       contactCardTitle: 'Свяжитесь со мной',


### PR DESCRIPTION
## Summary
- add a dedicated GitHub section near the top of the page
- embed profile summary card from github-profile-summary-cards
- add localized section text and polished card styling

## Validation
- npm run build (passes, with existing CSS budget warning)