### PR TITLE
refactor: extract GitHub summary into standalone component

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -132,31 +132,6 @@
   gap: 0.85rem;
 }
 
-.github-section {
-  gap: 0.7rem;
-}
-
-.github-card-link {
-  display: block;
-  text-decoration: none;
-  border-radius: 20px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  box-shadow: var(--shadow);
-  overflow: hidden;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.github-card-link:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
-}
-
-.github-card-image {
-  width: 100%;
-  display: block;
-}
-
 @media (max-width: 640px) {
   .hero-intro {
     grid-template-columns: 1fr;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,21 +22,13 @@
     </div>
   </section>
 
-  <section class="section github-section" id="github">
-    <div class="section-head">
-      <h2>{{ t.githubTitle }}</h2>
-      <p>{{ t.githubLead }}</p>
-    </div>
-    <a
-      class="github-card-link"
-      [href]="githubProfileUrl"
-      target="_blank"
-      rel="noopener noreferrer"
-      [attr.aria-label]="t.githubOpenProfile"
-    >
-      <img class="github-card-image" [src]="githubSummaryUrl" alt="GitHub profile details for developman2013" />
-    </a>
-  </section>
+  <app-github-summary
+    [title]="t.githubTitle"
+    [lead]="t.githubLead"
+    [openProfileLabel]="t.githubOpenProfile"
+    [summaryUrl]="githubSummaryUrl"
+    [profileUrl]="githubProfileUrl"
+  />
 
   <section id="materials" class="section">
     <div class="section-head">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MenuComponent } from './menu/menu.component';
 import { CardComponent } from './card/card.component';
 import { ContactComponent } from './contact/contact.component';
+import { GithubSummaryComponent } from './github-summary/github-summary.component';
 
 type Lang = 'en' | 'ru';
 type Theme = 'light' | 'dark';
@@ -46,7 +47,7 @@ type AppCopy = {
 
 @Component({
   selector: 'app-root',
-  imports: [MenuComponent, CardComponent, ContactComponent],
+  imports: [MenuComponent, CardComponent, ContactComponent, GithubSummaryComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/src/app/github-summary/github-summary.component.css
+++ b/src/app/github-summary/github-summary.component.css
@@ -1,0 +1,24 @@
+.github-section {
+  gap: 0.7rem;
+}
+
+.github-card-link {
+  display: block;
+  text-decoration: none;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.github-card-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
+}
+
+.github-card-image {
+  width: 100%;
+  display: block;
+}

--- a/src/app/github-summary/github-summary.component.html
+++ b/src/app/github-summary/github-summary.component.html
@@ -1,0 +1,15 @@
+<section class="section github-section" id="github">
+  <div class="section-head">
+    <h2>{{ title }}</h2>
+    <p>{{ lead }}</p>
+  </div>
+  <a
+    class="github-card-link"
+    [href]="profileUrl"
+    target="_blank"
+    rel="noopener noreferrer"
+    [attr.aria-label]="openProfileLabel"
+  >
+    <img class="github-card-image" [src]="summaryUrl" alt="GitHub profile details for developman2013" />
+  </a>
+</section>

--- a/src/app/github-summary/github-summary.component.ts
+++ b/src/app/github-summary/github-summary.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-github-summary',
+  imports: [],
+  templateUrl: './github-summary.component.html',
+  styleUrl: './github-summary.component.css'
+})
+export class GithubSummaryComponent {
+  @Input({ required: true }) title!: string;
+  @Input({ required: true }) lead!: string;
+  @Input({ required: true }) openProfileLabel!: string;
+  @Input({ required: true }) summaryUrl!: string;
+  @Input({ required: true }) profileUrl!: string;
+}


### PR DESCRIPTION
## Summary
- move GitHub summary section into a dedicated component
- keep existing behavior and bindings
- simplify app component by removing embedded section markup/styles

## Validation
- npm run build (passes; existing CSS budget warning remains)