### PR TITLE
perf: improve initial load with defer and image tuning

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -132,6 +132,28 @@
   gap: 0.85rem;
 }
 
+.section-skeleton {
+  padding: 0.35rem 0;
+}
+
+.skeleton-line {
+  display: block;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(125, 125, 128, 0.15), rgba(125, 125, 128, 0.3), rgba(125, 125, 128, 0.15));
+  background-size: 220% 100%;
+  animation: shimmer 1.1s linear infinite;
+}
+
+.skeleton-line.title {
+  width: min(340px, 70%);
+  height: 1.2rem;
+}
+
+.skeleton-line.body {
+  width: min(580px, 100%);
+  height: 0.92rem;
+}
+
 @media (max-width: 640px) {
   .hero-intro {
     grid-template-columns: 1fr;
@@ -153,5 +175,15 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,7 +9,16 @@
 <main class="layout">
   <section class="hero" id="top">
     <div class="hero-intro">
-      <img class="hero-avatar" src="assets/me.jpg" alt="Mikhail Pirahouski" />
+      <img
+        class="hero-avatar"
+        src="assets/me.jpg"
+        alt="Mikhail Pirahouski"
+        width="220"
+        height="220"
+        loading="eager"
+        fetchpriority="high"
+        decoding="async"
+      />
       <div class="hero-text">
         <p class="hero-kicker">{{ t.heroKicker }}</p>
         <h1>{{ name }}</h1>
@@ -22,51 +31,78 @@
     </div>
   </section>
 
-  <app-github-summary
-    [title]="t.githubTitle"
-    [lead]="t.githubLead"
-    [openProfileLabel]="t.githubOpenProfile"
-    [summaryUrl]="githubSummaryUrl"
-    [profileUrl]="githubProfileUrl"
-  />
+  @defer (on viewport) {
+    <app-github-summary
+      [title]="t.githubTitle"
+      [lead]="t.githubLead"
+      [openProfileLabel]="t.githubOpenProfile"
+      [summaryUrl]="githubSummaryUrl"
+      [profileUrl]="githubProfileUrl"
+    />
+  } @placeholder {
+    <section class="section">
+      <div class="section-head section-skeleton">
+        <span class="skeleton-line title"></span>
+        <span class="skeleton-line body"></span>
+      </div>
+    </section>
+  }
 
-  <section id="materials" class="section">
-    <div class="section-head">
-      <h2>{{ t.materialsTitle }}</h2>
-      <p>{{ t.materialsLead }}</p>
-    </div>
-    <div class="card-stack">
-      @for (item of t.materials; track item.tag) {
-        <app-card
-          [header]="item.header"
-          [description]="item.description"
-          [imgUrl]="item.imgUrl"
-          [extUrl]="item.extUrl ?? ''"
-          [tag]="item.tag"
-          [ctaLabel]="t.openSourceLabel"
-        />
-      }
-    </div>
-  </section>
+  @defer (on viewport) {
+    <section id="materials" class="section">
+      <div class="section-head">
+        <h2>{{ t.materialsTitle }}</h2>
+        <p>{{ t.materialsLead }}</p>
+      </div>
+      <div class="card-stack">
+        @for (item of t.materials; track item.tag) {
+          <app-card
+            [header]="item.header"
+            [description]="item.description"
+            [imgUrl]="item.imgUrl"
+            [extUrl]="item.extUrl ?? ''"
+            [tag]="item.tag"
+            [ctaLabel]="t.openSourceLabel"
+          />
+        }
+      </div>
+    </section>
+  } @placeholder {
+    <section id="materials" class="section">
+      <div class="section-head section-skeleton">
+        <span class="skeleton-line title"></span>
+        <span class="skeleton-line body"></span>
+      </div>
+    </section>
+  }
 
-  <section id="projects" class="section">
-    <div class="section-head">
-      <h2>{{ t.projectsTitle }}</h2>
-      <p>{{ t.projectsLead }}</p>
-    </div>
-    <div class="card-stack">
-      @for (item of t.projects; track item.tag) {
-        <app-card
-          [header]="item.header"
-          [description]="item.description"
-          [imgUrl]="item.imgUrl"
-          [extUrl]="item.extUrl ?? ''"
-          [tag]="item.tag"
-          [ctaLabel]="t.openSourceLabel"
-        />
-      }
-    </div>
-  </section>
+  @defer (on viewport) {
+    <section id="projects" class="section">
+      <div class="section-head">
+        <h2>{{ t.projectsTitle }}</h2>
+        <p>{{ t.projectsLead }}</p>
+      </div>
+      <div class="card-stack">
+        @for (item of t.projects; track item.tag) {
+          <app-card
+            [header]="item.header"
+            [description]="item.description"
+            [imgUrl]="item.imgUrl"
+            [extUrl]="item.extUrl ?? ''"
+            [tag]="item.tag"
+            [ctaLabel]="t.openSourceLabel"
+          />
+        }
+      </div>
+    </section>
+  } @placeholder {
+    <section id="projects" class="section">
+      <div class="section-head section-skeleton">
+        <span class="skeleton-line title"></span>
+        <span class="skeleton-line body"></span>
+      </div>
+    </section>
+  }
 
   <section class="section">
     <div class="section-head">

--- a/src/app/card/card.component.html
+++ b/src/app/card/card.component.html
@@ -1,6 +1,6 @@
 <article class="showcase-card" [id]="tag">
   <div class="media">
-    <img class="thumb" [src]="imgUrl" [alt]="header" />
+    <img class="thumb" [src]="imgUrl" [alt]="header" loading="lazy" decoding="async" />
   </div>
   <div class="content">
     <h3>{{ header }}</h3>

--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -1,5 +1,5 @@
 <article id="contact" class="contact-card">
-  <img class="avatar" src="assets/me.jpg" alt="Mikhail Pirahouski" />
+  <img class="avatar" src="assets/me.jpg" alt="Mikhail Pirahouski" loading="lazy" decoding="async" />
   <div class="contact-body">
     <h3>{{ title }}</h3>
     <p>{{ description }}</p>

--- a/src/app/github-summary/github-summary.component.html
+++ b/src/app/github-summary/github-summary.component.html
@@ -10,6 +10,12 @@
     rel="noopener noreferrer"
     [attr.aria-label]="openProfileLabel"
   >
-    <img class="github-card-image" [src]="summaryUrl" alt="GitHub profile details for developman2013" />
+    <img
+      class="github-card-image"
+      [src]="summaryUrl"
+      alt="GitHub profile details for developman2013"
+      loading="lazy"
+      decoding="async"
+    />
   </a>
 </section>

--- a/src/index.html
+++ b/src/index.html
@@ -1,12 +1,11 @@
 <!doctype html>
 <html lang="en" data-bs-theme="light" data-theme="light">
 <head>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <meta charset="utf-8">
   <title>Mikhail Prahouski</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preload" href="assets/me.jpg" as="image">
   <link rel="icon" type="image/svg+xml" href="assets/pirahouski-logo.svg">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- defer heavy sections with Angular @defer and lightweight placeholders
- optimize image loading attributes (priority/lazy/decoding)
- remove unused Bootstrap CDN payload from index
- preload hero avatar image

## Verification
- npm run build (pass)

## Risks
- deferred sections render when entering viewport, so visual order may appear progressively on slower devices
- app.component style budget warning already exists and remains non-blocking

## Rollback
- revert this PR commit to restore previous eager rendering and head includes