### PR TITLE
a11y: improve keyboard navigation and interaction semantics

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,3 +1,21 @@
+.skip-link {
+  position: absolute;
+  left: 0.8rem;
+  top: -56px;
+  z-index: 60;
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: top 0.18s ease;
+}
+
+.skip-link:focus-visible {
+  top: 0.8rem;
+}
+
 .layout {
   width: min(1120px, calc(100% - 2rem));
   margin: 1rem auto 4rem;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,5 @@
+<a class="skip-link" href="#main-content">{{ t.skipToContent }}</a>
+
 <app-menu
   [labels]="t.menu"
   [currentLang]="currentLang"
@@ -6,7 +8,7 @@
   (themeToggle)="onThemeToggle()"
 />
 
-<main class="layout">
+<main class="layout" id="main-content">
   <section class="hero" id="top">
     <div class="hero-intro">
       <img class="hero-avatar" src="assets/me.jpg" alt="Mikhail Pirahouski" />
@@ -17,8 +19,8 @@
       </div>
     </div>
     <div class="hero-actions">
-      <a [attr.href]="anchorHref('materials')" class="btn btn-primary">{{ t.readMaterials }}</a>
-      <a [attr.href]="anchorHref('projects')" class="btn btn-secondary">{{ t.exploreProjects }}</a>
+      <a [attr.href]="anchorHref('materials')" class="btn btn-primary" [attr.aria-label]="t.readMaterials">{{ t.readMaterials }}</a>
+      <a [attr.href]="anchorHref('projects')" class="btn btn-secondary" [attr.aria-label]="t.exploreProjects">{{ t.exploreProjects }}</a>
     </div>
   </section>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,6 +26,7 @@ type AppCopy = {
   };
   heroKicker: string;
   heroLead: string;
+  skipToContent: string;
   readMaterials: string;
   exploreProjects: string;
   materialsTitle: string;
@@ -69,6 +70,7 @@ export class AppComponent {
       },
       heroKicker: 'Software Engineer • Community Builder',
       heroLead: 'I build practical software, write technical stories, and turn delivery chaos into repeatable systems.',
+      skipToContent: 'Skip to content',
       readMaterials: 'Read materials',
       exploreProjects: 'Explore projects',
       materialsTitle: 'Materials',
@@ -161,6 +163,7 @@ export class AppComponent {
       },
       heroKicker: 'Инженер-программист • Создатель сообществ',
       heroLead: 'Я создаю практичные продукты, пишу технические материалы и превращаю хаос в поставке в повторяемые процессы.',
+      skipToContent: 'Перейти к содержанию',
       readMaterials: 'Читать материалы',
       exploreProjects: 'Смотреть проекты',
       materialsTitle: 'Материалы',

--- a/src/app/menu/menu.component.css
+++ b/src/app/menu/menu.component.css
@@ -35,7 +35,7 @@
   text-decoration: none;
   font-weight: 500;
   color: var(--ink);
-  opacity: 0.72;
+  opacity: 0.84;
   transition: opacity 0.18s ease;
 }
 

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -13,12 +13,13 @@
       class="theme-toggle"
       [class.active]="darkThemeEnabled"
       [attr.aria-label]="labels.theme"
+      [attr.aria-pressed]="darkThemeEnabled"
       (click)="toggleTheme()"
     >
       ☾
     </button>
 
-    <div class="lang-switch" [attr.aria-label]="labels.language">
+    <div class="lang-switch" role="group" [attr.aria-label]="labels.language">
       <button type="button" [class.active]="currentLang === 'en'" (click)="setLang('en')">EN</button>
       <button type="button" [class.active]="currentLang === 'ru'" (click)="setLang('ru')">RU</button>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,6 +56,12 @@ a {
   color: inherit;
 }
 
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 #top,
 #materials,
 #projects,
@@ -66,5 +72,16 @@ a {
 @media (max-width: 760px) {
   :root {
     --anchor-offset: 136px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- add skip link for keyboard users
- add aria-pressed for theme toggle and group semantics for language controls
- add global focus-visible styles for links and buttons
- add prefers-reduced-motion fallback
- slightly improve nav link readability by raising base contrast

## Verification
- npm run build (pass)

## Risks
- skip link positioning depends on topbar offset and may need minor tuning on atypical viewport heights

## Rollback
- revert this PR commit to restore previous interaction styling and semantics