### PR TITLE
ux: improve anchor navigation with smooth scroll and active state

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,7 @@
   [labels]="t.menu"
   [currentLang]="currentLang"
   [darkThemeEnabled]="currentTheme === 'dark'"
+  [activeSection]="activeSection"
   (langChange)="onLangChange($event)"
   (themeToggle)="onThemeToggle()"
 />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, Inject } from '@angular/core';
+import { Component, HostListener, Inject } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { MenuComponent } from './menu/menu.component';
 import { CardComponent } from './card/card.component';
@@ -9,6 +9,7 @@ import { buildGithubSummaryUrl, SITE_CONFIG } from './site.config';
 
 type Lang = 'en' | 'ru';
 type Theme = 'light' | 'dark';
+type Section = 'top' | 'materials' | 'projects' | 'contact';
 
 type ShowcaseItem = {
   header: string;
@@ -62,6 +63,7 @@ export class AppComponent {
   readonly githubProfileUrl = SITE_CONFIG.github.profileUrl;
   currentLang: Lang = this.detectLangFromUrl();
   currentTheme: Theme = this.detectTheme();
+  activeSection: Section = 'top';
 
   private canonicalLinkEl: HTMLLinkElement | null = null;
   private readonly baseUrl = 'https://pirahouski.com';
@@ -294,6 +296,13 @@ export class AppComponent {
     this.writeLangToUrl(this.currentLang);
     this.applyTheme(this.currentTheme);
     this.updateSeo();
+    this.syncActiveSection();
+  }
+
+  @HostListener('window:scroll')
+  @HostListener('window:hashchange')
+  onViewportChanged() {
+    this.syncActiveSection();
   }
 
   private detectLangFromUrl(): Lang {
@@ -351,6 +360,32 @@ export class AppComponent {
     }
     document.documentElement.setAttribute('data-theme', theme);
     document.documentElement.setAttribute('data-bs-theme', theme);
+  }
+
+  private syncActiveSection() {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const hash = window.location.hash.replace('#', '');
+    if (this.isSection(hash)) {
+      this.activeSection = hash;
+      return;
+    }
+
+    const sections: Section[] = ['top', 'materials', 'projects', 'contact'];
+    const scrollPosition = window.scrollY + 140;
+
+    for (let i = sections.length - 1; i >= 0; i--) {
+      const id = sections[i];
+      const node = document.getElementById(id);
+      if (node && node.offsetTop <= scrollPosition) {
+        this.activeSection = id;
+        return;
+      }
+    }
+
+    this.activeSection = 'top';
   }
 
   private updateSeo() {
@@ -460,5 +495,9 @@ export class AppComponent {
 
   private isLang(value: string | null | undefined): value is Lang {
     return value === 'en' || value === 'ru';
+  }
+
+  private isSection(value: string | null | undefined): value is Section {
+    return value === 'top' || value === 'materials' || value === 'projects' || value === 'contact';
   }
 }

--- a/src/app/menu/menu.component.css
+++ b/src/app/menu/menu.component.css
@@ -25,6 +25,10 @@
   font-size: 0.95rem;
 }
 
+.brand.active {
+  color: var(--accent);
+}
+
 .links {
   display: flex;
   align-items: center;
@@ -41,6 +45,11 @@
 
 .links a:hover {
   opacity: 1;
+}
+
+.links a.active {
+  opacity: 1;
+  color: var(--accent);
 }
 
 .controls {

--- a/src/app/menu/menu.component.html
+++ b/src/app/menu/menu.component.html
@@ -1,10 +1,10 @@
 <header class="topbar">
-  <a class="brand" [attr.href]="anchorHref('top')">pirahouski</a>
+  <a class="brand" [attr.href]="anchorHref('top')" [class.active]="activeSection === 'top'">pirahouski</a>
 
   <nav class="links" aria-label="Main">
-    <a [attr.href]="anchorHref('materials')">{{ labels.materials }}</a>
-    <a [attr.href]="anchorHref('projects')">{{ labels.projects }}</a>
-    <a [attr.href]="anchorHref('contact')">{{ labels.contact }}</a>
+    <a [attr.href]="anchorHref('materials')" [class.active]="activeSection === 'materials'" [attr.aria-current]="activeSection === 'materials' ? 'page' : null">{{ labels.materials }}</a>
+    <a [attr.href]="anchorHref('projects')" [class.active]="activeSection === 'projects'" [attr.aria-current]="activeSection === 'projects' ? 'page' : null">{{ labels.projects }}</a>
+    <a [attr.href]="anchorHref('contact')" [class.active]="activeSection === 'contact'" [attr.aria-current]="activeSection === 'contact' ? 'page' : null">{{ labels.contact }}</a>
   </nav>
 
   <div class="controls">

--- a/src/app/menu/menu.component.ts
+++ b/src/app/menu/menu.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 type Lang = 'en' | 'ru';
+type Section = 'top' | 'materials' | 'projects' | 'contact';
 
 type MenuLabels = {
   materials: string;
@@ -20,6 +21,7 @@ export class MenuComponent {
   @Input({ required: true }) labels!: MenuLabels;
   @Input() currentLang: Lang = 'en';
   @Input() darkThemeEnabled = false;
+  @Input() activeSection: Section = 'top';
   @Output() langChange = new EventEmitter<Lang>();
   @Output() themeToggle = new EventEmitter<void>();
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,6 +32,7 @@ body {
 }
 
 html {
+  scroll-behavior: smooth;
   scroll-padding-top: var(--anchor-offset);
 }
 


### PR DESCRIPTION
## Summary
- add active section tracking in app component based on hash and scroll position
- pass active section to menu and highlight current nav link
- set  on active nav item
- enable smooth scrolling globally while preserving anchor offset behavior

## Verification
- npm run build (pass)

## Risks
- active section threshold is static and can require tuning if header height changes significantly

## Rollback
- revert this PR commit to restore previous non-highlighted menu behavior