### PR TITLE
feat: add privacy-first analytics event tracking

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -41,6 +41,7 @@
       [openProfileLabel]="t.githubOpenProfile"
       [summaryUrl]="githubSummaryUrl"
       [profileUrl]="githubProfileUrl"
+      (openProfileClick)="onOpenGithubProfile()"
     />
   } @placeholder {
     <section class="section">
@@ -66,6 +67,7 @@
             [extUrl]="item.extUrl ?? ''"
             [tag]="item.tag"
             [ctaLabel]="t.openSourceLabel"
+            (ctaClick)="onCardCtaClick($event)"
           />
         }
       </div>
@@ -91,6 +93,7 @@
       [extUrl]="featuredProject.extUrl ?? ''"
       [tag]="featuredProject.tag"
       [ctaLabel]="t.openSourceLabel"
+      (ctaClick)="onCardCtaClick($event)"
     />
   </section>
 
@@ -109,6 +112,7 @@
             [extUrl]="item.extUrl ?? ''"
             [tag]="item.tag"
             [ctaLabel]="t.openSourceLabel"
+            (ctaClick)="onCardCtaClick($event)"
           />
         }
       </div>
@@ -132,6 +136,8 @@
       [description]="t.contactCardText"
       [telegramLabel]="t.telegramLabel"
       [emailLabel]="t.emailLabel"
+      (telegramClick)="onTelegramOpen()"
+      (emailClick)="onEmailOpen()"
     />
   </section>
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { buildGithubSummaryUrl, SITE_CONFIG } from './site.config';
 
 type Theme = 'light' | 'dark';
 type Section = 'top' | 'materials' | 'projects' | 'contact';
+type AnalyticsProps = Record<string, string | number | boolean>;
 
 type AppCopy = {
   seoTitle: string;
@@ -155,12 +156,30 @@ export class AppComponent {
     this.currentLang = lang;
     this.writeLangToUrl(lang);
     this.updateSeo();
+    this.trackEvent('language_switch', { lang });
   }
 
   onThemeToggle() {
     this.currentTheme = this.currentTheme === 'dark' ? 'light' : 'dark';
     this.applyTheme(this.currentTheme);
     this.writeThemeToStorage(this.currentTheme);
+    this.trackEvent('theme_toggle', { theme: this.currentTheme });
+  }
+
+  onCardCtaClick(tag: string) {
+    this.trackEvent('card_cta_click', { tag, lang: this.currentLang });
+  }
+
+  onOpenGithubProfile() {
+    this.trackEvent('github_profile_open', { lang: this.currentLang });
+  }
+
+  onTelegramOpen() {
+    this.trackEvent('contact_telegram_open', { lang: this.currentLang });
+  }
+
+  onEmailOpen() {
+    this.trackEvent('contact_email_open', { lang: this.currentLang });
   }
 
   anchorHref(fragment: 'materials' | 'projects'): string {
@@ -176,6 +195,7 @@ export class AppComponent {
     this.applyTheme(this.currentTheme);
     this.updateSeo();
     this.syncActiveSection();
+    this.initAnalytics();
   }
 
   @HostListener('window:scroll')
@@ -378,5 +398,33 @@ export class AppComponent {
 
   private isSection(value: string | null | undefined): value is Section {
     return value === 'top' || value === 'materials' || value === 'projects' || value === 'contact';
+  }
+
+  private initAnalytics() {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const analytics = SITE_CONFIG.analytics;
+    if (!analytics.enabled || analytics.provider !== 'plausible') {
+      return;
+    }
+
+    if (!document.querySelector(`script[src="${analytics.scriptUrl}"]`)) {
+      const script = document.createElement('script');
+      script.defer = true;
+      script.dataset['domain'] = analytics.domain;
+      script.src = analytics.scriptUrl;
+      document.head.appendChild(script);
+    }
+  }
+
+  private trackEvent(name: string, props: AnalyticsProps) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const plausible = (window as Window & { plausible?: (eventName: string, eventData?: { props?: AnalyticsProps }) => void }).plausible;
+    plausible?.(name, { props });
   }
 }

--- a/src/app/card/card.component.html
+++ b/src/app/card/card.component.html
@@ -10,7 +10,7 @@
       }
     </div>
     @if (extUrl) {
-      <a class="cta" target="_blank" rel="noopener" [href]="extUrl">{{ ctaLabel }}</a>
+      <a class="cta" target="_blank" rel="noopener" [href]="extUrl" (click)="onCtaClick()">{{ ctaLabel }}</a>
     }
   </div>
 </article>

--- a/src/app/card/card.component.ts
+++ b/src/app/card/card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
 @Component({
   selector: 'app-card',
@@ -13,6 +13,7 @@ export class CardComponent implements OnChanges {
   @Input() extUrl: string = '';
   @Input() tag: string = '';
   @Input() ctaLabel: string = 'Open source';
+  @Output() ctaClick = new EventEmitter<string>();
 
   public descriptionArr: string[] = [];
 
@@ -21,5 +22,11 @@ export class CardComponent implements OnChanges {
       .split('\n')
       .map((paragraph) => paragraph.trim())
       .filter(Boolean);
+  }
+
+  onCtaClick() {
+    if (this.extUrl) {
+      this.ctaClick.emit(this.tag);
+    }
   }
 }

--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -4,8 +4,8 @@
     <h3>{{ title }}</h3>
     <p>{{ description }}</p>
     <div class="contact-actions">
-      <a target="_blank" rel="noopener" href="https://t.me/mihailych007">{{ telegramLabel }}</a>
-      <a target="_blank" rel="noopener" href="mailto:mikhail@pirahouski.com">{{ emailLabel }}</a>
+      <a target="_blank" rel="noopener" href="https://t.me/mihailych007" (click)="onTelegramClick()">{{ telegramLabel }}</a>
+      <a target="_blank" rel="noopener" href="mailto:mikhail@pirahouski.com" (click)="onEmailClick()">{{ emailLabel }}</a>
     </div>
   </div>
 </article>

--- a/src/app/contact/contact.component.ts
+++ b/src/app/contact/contact.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-contact',
@@ -11,4 +11,14 @@ export class ContactComponent {
   @Input() description: string = '';
   @Input() telegramLabel: string = 'Telegram';
   @Input() emailLabel: string = 'Email';
+  @Output() telegramClick = new EventEmitter<void>();
+  @Output() emailClick = new EventEmitter<void>();
+
+  onTelegramClick() {
+    this.telegramClick.emit();
+  }
+
+  onEmailClick() {
+    this.emailClick.emit();
+  }
 }

--- a/src/app/github-summary/github-summary.component.html
+++ b/src/app/github-summary/github-summary.component.html
@@ -9,6 +9,7 @@
     target="_blank"
     rel="noopener noreferrer"
     [attr.aria-label]="openProfileLabel"
+    (click)="onOpenProfileClick()"
   >
     <img
       class="github-card-image"

--- a/src/app/github-summary/github-summary.component.ts
+++ b/src/app/github-summary/github-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-github-summary',
@@ -12,4 +12,9 @@ export class GithubSummaryComponent {
   @Input({ required: true }) openProfileLabel!: string;
   @Input({ required: true }) summaryUrl!: string;
   @Input({ required: true }) profileUrl!: string;
+  @Output() openProfileClick = new EventEmitter<void>();
+
+  onOpenProfileClick() {
+    this.openProfileClick.emit();
+  }
 }

--- a/src/app/site.config.ts
+++ b/src/app/site.config.ts
@@ -6,6 +6,12 @@ export const SITE_CONFIG = {
       light: 'default',
       dark: 'dark'
     }
+  },
+  analytics: {
+    provider: 'plausible',
+    enabled: true,
+    domain: 'pirahouski.com',
+    scriptUrl: 'https://plausible.io/js/script.js'
   }
 } as const;
 


### PR DESCRIPTION
## Summary
- add Plausible analytics configuration in site config
- load analytics script conditionally in app bootstrap
- track key events: language switch, theme toggle, card CTA clicks, GitHub profile open, contact link opens
- wire child components to emit analytics-ready output events

## Privacy
- uses Plausible script without cookie banner requirements
- only high-level interaction events are tracked

## Verification
- npm run build (pass)

## Risks
- analytics script can be blocked by browser extensions, which will silently reduce event volume

## Rollback
- revert this PR commit to disable analytics loading and event hooks