### PR TITLE
security: bump hono to patched 4.12.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9349,9 +9349,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "overrides": {
     "@hono/node-server": "1.19.11",
-    "hono": "4.12.5",
+    "hono": "4.12.7",
     "express-rate-limit": "8.2.2",
     "qs": "6.15.0",
     "tmp": "0.2.5",


### PR DESCRIPTION
## Summary
- fix Dependabot alert #80 (Hono prototype pollution)
- bump  override to 
- refresh lockfile to enforce patched transitive dependency

## Verification
- npm ls hono -> 4.12.7
- npm run build (pass)

## Risk
- low; transitive dependency patch update only

## Rollback
- revert commit 5166a17