### PR TITLE
chore: add OpenAI ChatGPT devcontainer extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
         "Angular.ng-template",
         "ms-vscode.vscode-typescript-next",
         "ms-playwright.playwright",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "openai.chatgpt"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- add the `openai.chatgpt` VS Code extension to the devcontainer

## Validation
- `npm run build`

## Risks
- low risk: devcontainer-only change
- existing CSS budget warning remains in `src/app/app.component.css`

## Rollback
- revert this PR or remove `openai.chatgpt` from `.devcontainer/devcontainer.json`