### PR TITLE
fix: persist codex and vscode data in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
 
+RUN mkdir -p /home/node/.codex /home/node/.vscode-server \
+    && chown -R node:node /home/node/.codex /home/node/.vscode-server
+
 RUN npm install --global @angular/cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,10 @@
     "dockerfile": "Dockerfile"
   },
   "remoteUser": "node",
+  "mounts": [
+    "source=pirahouski-codex-home,target=/home/node/.codex,type=volume",
+    "source=pirahouski-vscode-server,target=/home/node/.vscode-server,type=volume"
+  ],
   "postCreateCommand": "npm ci",
   "forwardPorts": [4200],
   "portsAttributes": {


### PR DESCRIPTION
## Summary
- persist `/home/node/.codex` and `/home/node/.vscode-server` via named Docker volumes
- pre-create both directories in the devcontainer image and assign ownership to the `node` user

## User-facing impact
- developer container sessions keep Codex auth and VS Code server state between rebuilds

## Validation
- `npm run build`

## Risks
- existing local devcontainer volumes may need one rebuild cycle to align with the new mounts

## Rollback
- revert this PR to remove the named volume mounts and directory bootstrap step