### PR TITLE
Add core skills section

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -35,6 +35,8 @@
     </div>
   </section>
 
+  <app-core-skills-section [currentLang]="currentLang" [copy]="coreSkillsCopy" />
+
   <app-experience-section [currentLang]="currentLang" [copy]="experienceSectionCopy" />
 
   @defer (on viewport) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { Analytics, getAnalytics, isSupported, logEvent } from 'firebase/analyti
 import { MenuComponent } from './menu/menu.component';
 import { CardComponent } from './card/card.component';
 import { ContactComponent } from './contact/contact.component';
+import { CoreSkillsCopy, CoreSkillsSectionComponent } from './core-skills-section/core-skills-section.component';
 import { ExperienceSectionComponent, ExperienceSectionCopy } from './experience-section/experience-section.component';
 import { GithubSummaryComponent } from './github-summary/github-summary.component';
 import { APP_CONTENT, Lang, ShowcaseItem } from './content.config';
@@ -33,6 +34,9 @@ type AppCopy = {
   viewExperience: string;
   readMaterials: string;
   exploreProjects: string;
+  coreSkillsEyebrow: string;
+  coreSkillsTitle: string;
+  coreSkillsLead: string;
   experienceEyebrow: string;
   experienceTitle: string;
   experienceLead: string;
@@ -58,7 +62,7 @@ type AppCopy = {
 
 @Component({
   selector: 'app-root',
-  imports: [MenuComponent, CardComponent, ContactComponent, ExperienceSectionComponent, GithubSummaryComponent],
+  imports: [MenuComponent, CardComponent, ContactComponent, CoreSkillsSectionComponent, ExperienceSectionComponent, GithubSummaryComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
@@ -85,12 +89,15 @@ export class AppComponent {
         language: 'Language switch',
         theme: 'Toggle dark theme'
       },
-      heroKicker: 'Software Engineer • Community Builder',
-      heroLead: 'I build practical software, write technical stories, and turn delivery chaos into repeatable systems.',
+      heroKicker: 'Full-stack Software Engineer • Community Builder',
+      heroLead: 'I build .NET and Angular products, write technical stories, and turn delivery chaos into repeatable systems.',
       skipToContent: 'Skip to content',
       viewExperience: 'View experience',
       readMaterials: 'Read materials',
       exploreProjects: 'Explore projects',
+      coreSkillsEyebrow: 'Core stack',
+      coreSkillsTitle: 'Skills Snapshot',
+      coreSkillsLead: 'A compact map of the technologies and practices I use to ship production-facing systems.',
       experienceEyebrow: 'Career timeline',
       experienceTitle: 'Work Experience',
       experienceLead: 'Seven delivery-heavy engagements across product engineering, cloud systems, developer tooling, and team coordination.',
@@ -124,12 +131,15 @@ export class AppComponent {
         language: 'Переключение языка',
         theme: 'Переключить темную тему'
       },
-      heroKicker: 'Инженер-программист • Создатель сообществ',
-      heroLead: 'Я создаю практичные продукты, пишу технические материалы и превращаю хаос в поставке в повторяемые процессы.',
+      heroKicker: 'Full-stack инженер • Создатель сообществ',
+      heroLead: 'Я создаю продукты на .NET и Angular, пишу технические материалы и превращаю хаос в поставке в повторяемые процессы.',
       skipToContent: 'Перейти к содержанию',
       viewExperience: 'Смотреть опыт',
       readMaterials: 'Читать материалы',
       exploreProjects: 'Смотреть проекты',
+      coreSkillsEyebrow: 'Core stack',
+      coreSkillsTitle: 'Срез навыков',
+      coreSkillsLead: 'Компактная карта технологий и практик, которые я использую для поставки production-facing систем.',
       experienceEyebrow: 'Карьерная траектория',
       experienceTitle: 'Опыт работы',
       experienceLead: 'Семь насыщенных проектов на стыке продуктовой разработки, облачной инфраструктуры, инженерных инструментов и координации команд.',
@@ -164,6 +174,14 @@ export class AppComponent {
 
   get projects(): ShowcaseItem[] {
     return APP_CONTENT[this.currentLang].projects;
+  }
+
+  get coreSkillsCopy(): CoreSkillsCopy {
+    return {
+      eyebrow: this.t.coreSkillsEyebrow,
+      title: this.t.coreSkillsTitle,
+      lead: this.t.coreSkillsLead
+    };
   }
 
   get experienceSectionCopy(): ExperienceSectionCopy {

--- a/src/app/core-skills-section/core-skills-section.component.css
+++ b/src/app/core-skills-section/core-skills-section.component.css
@@ -1,0 +1,69 @@
+.core-skills-section {
+  gap: 1rem;
+}
+
+.core-skills-head {
+  max-width: 72ch;
+}
+
+.core-skills-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.core-skill-card {
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--accent) 9%, transparent), transparent 38%),
+    var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.core-skill-card h3 {
+  margin: 0;
+  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.12;
+  font-size: 1.12rem;
+}
+
+.core-skill-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.core-skill-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.core-skill-tags span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.8rem;
+  padding: 0.34rem 0.62rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 88%, white 12%);
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .core-skills-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .core-skills-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/core-skills-section/core-skills-section.component.html
+++ b/src/app/core-skills-section/core-skills-section.component.html
@@ -1,0 +1,28 @@
+<section class="section core-skills-section">
+  <div class="section-head core-skills-head">
+    <p class="section-kicker">{{ copy().eyebrow }}</p>
+    <h2>{{ copy().title }}</h2>
+    <p>{{ copy().lead }}</p>
+  </div>
+
+  @if (skillGroups$ | async; as skillGroups) {
+    <div class="core-skills-grid">
+      @for (group of skillGroups; track group.title) {
+        <article class="core-skill-card">
+          <h3>{{ group.title }}</h3>
+          <p>{{ group.summary }}</p>
+          <div class="core-skill-tags">
+            @for (item of group.items; track item) {
+              <span>{{ item }}</span>
+            }
+          </div>
+        </article>
+      }
+    </div>
+  } @else {
+    <div class="section-head section-skeleton">
+      <span class="skeleton-line title"></span>
+      <span class="skeleton-line body"></span>
+    </div>
+  }
+</section>

--- a/src/app/core-skills-section/core-skills-section.component.spec.ts
+++ b/src/app/core-skills-section/core-skills-section.component.spec.ts
@@ -1,0 +1,45 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CoreSkillsSectionComponent } from './core-skills-section.component';
+
+describe('CoreSkillsSectionComponent', () => {
+  let fixture: ComponentFixture<CoreSkillsSectionComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CoreSkillsSectionComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CoreSkillsSectionComponent);
+    fixture.componentRef.setInput('currentLang', 'en');
+    fixture.componentRef.setInput('copy', {
+      eyebrow: 'Core stack',
+      title: 'Skills',
+      lead: 'Selected skills'
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should render skill groups from json', () => {
+    const req = httpMock.expectOne('assets/core-skills.json');
+    req.flush({
+      en: [{ title: 'Frontend', summary: 'UI work', items: ['Angular'] }],
+      ru: []
+    });
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.core-skill-card h3')?.textContent).toContain('Frontend');
+    expect(compiled.querySelector('.core-skill-tags span')?.textContent).toContain('Angular');
+  });
+});

--- a/src/app/core-skills-section/core-skills-section.component.ts
+++ b/src/app/core-skills-section/core-skills-section.component.ts
@@ -1,0 +1,39 @@
+import { AsyncPipe } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { combineLatest, map, shareReplay } from 'rxjs';
+import { Lang } from '../content.config';
+
+type SkillGroup = {
+  title: string;
+  summary: string;
+  items: string[];
+};
+
+type SkillDictionary = Record<Lang, SkillGroup[]>;
+
+export type CoreSkillsCopy = {
+  eyebrow: string;
+  title: string;
+  lead: string;
+};
+
+@Component({
+  selector: 'app-core-skills-section',
+  imports: [AsyncPipe],
+  templateUrl: './core-skills-section.component.html',
+  styleUrl: './core-skills-section.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CoreSkillsSectionComponent {
+  readonly currentLang = input.required<Lang>();
+  readonly copy = input.required<CoreSkillsCopy>();
+
+  private readonly http = inject(HttpClient);
+  private readonly skillsContent$ = this.http.get<SkillDictionary>('assets/core-skills.json').pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+  readonly skillGroups$ = combineLatest([this.skillsContent$, toObservable(this.currentLang)]).pipe(
+    map(([content, lang]) => content[lang] ?? [])
+  );
+}

--- a/src/assets/core-skills.json
+++ b/src/assets/core-skills.json
@@ -1,0 +1,66 @@
+{
+  "en": [
+    {
+      "title": "Full-stack engineering",
+      "summary": "Product-facing development across backend services, web UI, and mobile-adjacent delivery.",
+      "items": ["C#", "TypeScript", "JavaScript", ".NET", "ASP.NET API", "Angular", "HTML", "CSS"]
+    },
+    {
+      "title": "Cloud and integration",
+      "summary": "Cloud services, messaging, storage, and observability for delivery-focused systems.",
+      "items": ["Microsoft Azure", "VK Cloud Solutions", "Google Cloud", "Service Bus", "Azure Functions", "Blob Storage", "Application Insights"]
+    },
+    {
+      "title": "Data layer",
+      "summary": "Relational and document stores used across portals, migration tools, and product platforms.",
+      "items": ["SQL Server", "PostgreSQL", "MongoDB", "Cosmos DB", "MySQL", "SQLite", "Redis"]
+    },
+    {
+      "title": "Delivery practice",
+      "summary": "Practical ownership of release flow, automation, and support for running products.",
+      "items": ["CI/CD", "Docker", "GitHub Actions", "Azure DevOps", "Deployment", "Maintenance", "Support"]
+    },
+    {
+      "title": "Engineering methods",
+      "summary": "Team practices that keep delivery predictable while requirements evolve.",
+      "items": ["Agile", "Scrum", "Kanban", "Pair Programming", "Requirements Analysis", "Bug Investigation"]
+    },
+    {
+      "title": "AI-assisted workflow",
+      "summary": "Daily engineering acceleration with modern coding assistants and agent tooling.",
+      "items": ["GitHub Copilot", "Codex", "VS Code", "Visual Studio"]
+    }
+  ],
+  "ru": [
+    {
+      "title": "Full-stack разработка",
+      "summary": "Продуктовая разработка на стыке backend-сервисов, web-интерфейсов и mobile-adjacent поставки.",
+      "items": ["C#", "TypeScript", "JavaScript", ".NET", "ASP.NET API", "Angular", "HTML", "CSS"]
+    },
+    {
+      "title": "Cloud и интеграции",
+      "summary": "Облачные сервисы, сообщения, хранение данных и наблюдаемость для delivery-focused систем.",
+      "items": ["Microsoft Azure", "VK Cloud Solutions", "Google Cloud", "Service Bus", "Azure Functions", "Blob Storage", "Application Insights"]
+    },
+    {
+      "title": "Data layer",
+      "summary": "Реляционные и документные хранилища для порталов, migration tooling и продуктовых платформ.",
+      "items": ["SQL Server", "PostgreSQL", "MongoDB", "Cosmos DB", "MySQL", "SQLite", "Redis"]
+    },
+    {
+      "title": "Delivery practice",
+      "summary": "Практическое владение релизным процессом, автоматизацией и поддержкой работающих продуктов.",
+      "items": ["CI/CD", "Docker", "GitHub Actions", "Azure DevOps", "Deployment", "Maintenance", "Support"]
+    },
+    {
+      "title": "Engineering methods",
+      "summary": "Командные практики, которые помогают сохранять предсказуемую поставку при меняющихся требованиях.",
+      "items": ["Agile", "Scrum", "Kanban", "Pair Programming", "Requirements Analysis", "Bug Investigation"]
+    },
+    {
+      "title": "AI-assisted workflow",
+      "summary": "Ускорение ежедневной разработки с помощью современных coding assistants и agent tooling.",
+      "items": ["GitHub Copilot", "Codex", "VS Code", "Visual Studio"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated Core Skills section after the hero
- move skills content into assets/core-skills.json
- slightly sharpen hero positioning around .NET and Angular full-stack work

## Validation
- npm run build

## Notes
- the local CV PDF remains untracked and is not part of this branch