### PR TITLE
Remove featured project section

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -86,22 +86,6 @@
     </section>
   }
 
-  <section class="section">
-    <div class="section-head">
-      <h2>{{ t.featuredTitle }}</h2>
-      <p>{{ t.featuredLead }}</p>
-    </div>
-    <app-card
-      [header]="featuredProject.header"
-      [description]="featuredProject.description"
-      [imgUrl]="featuredProject.imgUrl"
-      [extUrl]="featuredProject.extUrl ?? ''"
-      [tag]="featuredProject.tag"
-      [ctaLabel]="t.openSourceLabel"
-      (ctaClick)="onCardCtaClick($event)"
-    />
-  </section>
-
   @defer (on viewport) {
     <section id="projects" class="section">
       <div class="section-head">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -42,8 +42,6 @@ type AppCopy = {
   experienceLead: string;
   experienceHighlightsLabel: string;
   experienceStackLabel: string;
-  featuredTitle: string;
-  featuredLead: string;
   materialsTitle: string;
   materialsLead: string;
   projectsTitle: string;
@@ -103,8 +101,6 @@ export class AppComponent {
       experienceLead: 'Seven delivery-heavy engagements across product engineering, cloud systems, developer tooling, and team coordination.',
       experienceHighlightsLabel: 'Core contributions',
       experienceStackLabel: 'Stack',
-      featuredTitle: 'Featured project',
-      featuredLead: 'Highlighted production-facing project from my portfolio.',
       materialsTitle: 'Materials',
       materialsLead: 'Selected publications on automation and engineering productivity.',
       projectsTitle: 'Code & Projects',
@@ -145,8 +141,6 @@ export class AppComponent {
       experienceLead: 'Семь насыщенных проектов на стыке продуктовой разработки, облачной инфраструктуры, инженерных инструментов и координации команд.',
       experienceHighlightsLabel: 'Ключевой вклад',
       experienceStackLabel: 'Стек',
-      featuredTitle: 'Рекомендуемый проект',
-      featuredLead: 'Выделенный продуктовый проект из моего портфолио.',
       materialsTitle: 'Материалы',
       materialsLead: 'Выбранные публикации про автоматизацию и инженерную эффективность.',
       projectsTitle: 'Код и проекты',
@@ -192,11 +186,6 @@ export class AppComponent {
       highlightsLabel: this.t.experienceHighlightsLabel,
       stackLabel: this.t.experienceStackLabel
     };
-  }
-
-  get featuredProject(): ShowcaseItem {
-    const content = APP_CONTENT[this.currentLang];
-    return content.projects.find((item) => item.tag === content.featuredProjectTag) ?? content.projects[0];
   }
 
   get githubSummaryUrl(): string {

--- a/src/app/content.config.ts
+++ b/src/app/content.config.ts
@@ -9,14 +9,12 @@ export type ShowcaseItem = {
 };
 
 type LocalizedContent = {
-  featuredProjectTag: string;
   materials: ShowcaseItem[];
   projects: ShowcaseItem[];
 };
 
 export const APP_CONTENT: Record<Lang, LocalizedContent> = {
   en: {
-    featuredProjectTag: 'lord-of-time-project',
     materials: [
       {
         header: 'Automation through the eyes of a developer: GitHub Actions for a startup',
@@ -84,7 +82,6 @@ export const APP_CONTENT: Record<Lang, LocalizedContent> = {
     ]
   },
   ru: {
-    featuredProjectTag: 'lord-of-time-project',
     materials: [
       {
         header: 'Автоматизация глазами разработчика: GitHub Actions для стартапа',


### PR DESCRIPTION
## Summary
- remove the Featured project section from the landing page
- delete the related copy and content config fields that are no longer used

## Verification
- npm run build
- verified in Chromium desktop viewport
- verified in Chromium mobile viewport

## Risks
- low risk, limited to page content flow between Materials and Projects

## Rollback
- revert commit a091fc9
