### PR TITLE
Add active menu highlight on scroll

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,6 +4,8 @@ import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
+  const sectionIds = ['top', 'experience', 'materials', 'projects', 'contact'] as const;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
@@ -29,4 +31,53 @@ describe('AppComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('#experience h2')?.textContent).toContain('Work Experience');
   });
+
+  it('should update the active menu section from the scroll position', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+
+    mockSectionOffsets({
+      top: 0,
+      experience: 240,
+      materials: 860,
+      projects: 1420,
+      contact: 2100
+    });
+
+    spyOnProperty(window, 'scrollY', 'get').and.returnValue(920);
+
+    app.onViewportChanged();
+
+    expect(app.activeSection).toBe('materials');
+  });
+
+  it('should resync the active section after the view initializes', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    const syncActiveSectionSpy = spyOn<any>(app, 'syncActiveSection');
+    const requestAnimationFrameSpy = spyOn(window, 'requestAnimationFrame').and.callFake((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    app.ngAfterViewInit();
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalled();
+    expect(syncActiveSectionSpy).toHaveBeenCalled();
+  });
+
+  function mockSectionOffsets(offsets: Record<(typeof sectionIds)[number], number>) {
+    const elements = new Map<string, HTMLElement>();
+
+    for (const sectionId of sectionIds) {
+      const element = document.createElement('section');
+      Object.defineProperty(element, 'offsetTop', {
+        configurable: true,
+        value: offsets[sectionId]
+      });
+      elements.set(sectionId, element);
+    }
+
+    spyOn(document, 'getElementById').and.callFake((id: string) => elements.get(id) ?? null);
+  }
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostListener, Inject } from '@angular/core';
+import { AfterViewInit, Component, HostListener, Inject } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { initializeApp } from 'firebase/app';
 import { Analytics, getAnalytics, isSupported, logEvent } from 'firebase/analytics';
@@ -64,7 +64,7 @@ type AppCopy = {
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
   readonly name = 'Mikhail Pirahouski';
   readonly githubProfileUrl = SITE_CONFIG.github.profileUrl;
   currentLang: Lang = this.detectLangFromUrl();
@@ -241,6 +241,14 @@ export class AppComponent {
     this.initAnalytics();
   }
 
+  ngAfterViewInit() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.requestAnimationFrame(() => this.syncActiveSection());
+  }
+
   @HostListener('window:scroll')
   @HostListener('window:hashchange')
   onViewportChanged() {
@@ -306,12 +314,6 @@ export class AppComponent {
 
   private syncActiveSection() {
     if (typeof window === 'undefined' || typeof document === 'undefined') {
-      return;
-    }
-
-    const hash = window.location.hash.replace('#', '');
-    if (this.isSection(hash)) {
-      this.activeSection = hash;
       return;
     }
 
@@ -437,10 +439,6 @@ export class AppComponent {
 
   private isLang(value: string | null | undefined): value is Lang {
     return value === 'en' || value === 'ru';
-  }
-
-  private isSection(value: string | null | undefined): value is Section {
-    return value === 'top' || value === 'experience' || value === 'materials' || value === 'projects' || value === 'contact';
   }
 
   private initAnalytics() {


### PR DESCRIPTION
## Summary
- update active menu state based on the current scroll position instead of a stale hash
- resync the active section after initial render for anchor deep-links
- add regression coverage for scroll-based highlighting

## Validation
- npm run build
- npm run test:smoke
- visual verification in Chromium for desktop and mobile

## Risks
- menu highlight behavior now depends on section offsets and the existing 140px scroll threshold
- ng test is currently blocked in this container by Chromium sandbox limits in Karma

## Rollback
- revert commit 509699d
