### PR TITLE
Harden client-side security defaults

### DIFF
--- a/src/app/card/card.component.html
+++ b/src/app/card/card.component.html
@@ -10,7 +10,7 @@
       }
     </div>
     @if (extUrl) {
-      <a class="cta" target="_blank" rel="noopener" [href]="extUrl" (click)="onCtaClick()">{{ ctaLabel }}</a>
+      <a class="cta" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer" [href]="extUrl" (click)="onCtaClick()">{{ ctaLabel }}</a>
     }
   </div>
 </article>

--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -4,8 +4,8 @@
     <h3>{{ title }}</h3>
     <p>{{ description }}</p>
     <div class="contact-actions">
-      <a target="_blank" rel="noopener" href="https://t.me/mihailych007" (click)="onTelegramClick()">{{ telegramLabel }}</a>
-      <a target="_blank" rel="noopener" href="mailto:mikhail@pirahouski.com" (click)="onEmailClick()">{{ emailLabel }}</a>
+      <a target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer" href="https://t.me/mihailych007" (click)="onTelegramClick()">{{ telegramLabel }}</a>
+      <a target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer" href="mailto:mikhail@pirahouski.com" (click)="onEmailClick()">{{ emailLabel }}</a>
     </div>
   </div>
 </article>

--- a/src/app/content.config.ts
+++ b/src/app/content.config.ts
@@ -54,7 +54,7 @@ export const APP_CONTENT: Record<Lang, LocalizedContent> = {
         header: 'Student hackathon “math_hack”',
         description: 'As part of MSP, our student team organized the first university hackathon.\nWe handled sponsorship, schedule, branding and promotion, and gathered more than fifty participants.',
         imgUrl: 'assets/05.png',
-        extUrl: 'http://www.gsu.by/ru/node/449',
+        extUrl: 'https://www.gsu.by/ru/node/449',
         tag: 'student-hackathon-event'
       }
     ],
@@ -121,7 +121,7 @@ export const APP_CONTENT: Record<Lang, LocalizedContent> = {
         header: 'Студенческий хакатон «math_hack»',
         description: 'В рамках MSP наша студенческая команда организовала первый университетский хакатон.\nМы собрали спонсоров, подготовили расписание и промо, и привлекли более 50 участников.',
         imgUrl: 'assets/05.png',
-        extUrl: 'http://www.gsu.by/ru/node/449',
+        extUrl: 'https://www.gsu.by/ru/node/449',
         tag: 'student-hackathon-event'
       }
     ],

--- a/src/app/github-summary/github-summary.component.html
+++ b/src/app/github-summary/github-summary.component.html
@@ -8,6 +8,7 @@
     [href]="profileUrl"
     target="_blank"
     rel="noopener noreferrer"
+    referrerpolicy="no-referrer"
     [attr.aria-label]="openProfileLabel"
     (click)="onOpenProfileClick()"
   >
@@ -17,6 +18,7 @@
       alt="GitHub profile details for developman2013"
       loading="lazy"
       decoding="async"
+      referrerpolicy="no-referrer"
     />
   </a>
 </section>

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,11 @@
   <title>Mikhail Pirahouski | Software Engineer Portfolio</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests; img-src 'self' data: https://pirahouski.com https://streak-stats.demolab.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://www.google-analytics.com https://firebaselogging.googleapis.com https://*.googleapis.com https://*.gstatic.com; font-src 'self' data:; manifest-src 'self';"
+  >
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="description" content="Portfolio of Mikhail Pirahouski: engineering projects, technical publications, and collaboration contacts.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Mikhail Pirahouski">


### PR DESCRIPTION
## Summary

- harden the static site with a client-side Content Security Policy and referrer policy
- remove the remaining insecure external content link downgrade path
- prevent opener/referrer leakage on external profile and contact links

## Changes

- added a CSP meta tag in `src/index.html` with restrictive defaults for scripts, frames, objects, and cross-origin connections
- added a `referrer` policy meta tag to reduce cross-site referral leakage
- switched the `gsu.by` showcase links from `http` to `https`
- added `rel="noopener noreferrer"` and `referrerpolicy="no-referrer"` to external links and the GitHub summary image link

## Validation

- [x] `npm run build`
- [x] Manual verification done for changed behavior

Manual verification notes:
- verified desktop rendering in headless Chrome at `1440px`
- verified mobile rendering in headless Chrome at `390px`
- confirmed `npm audit --package-lock-only` reports `0` vulnerabilities

## Risks

- the CSP intentionally restricts future third-party scripts, images, and analytics endpoints; adding new external providers will require updating the allowlist
- local static previews still show a missing `assets/runtime-config.js` unless deployment injects it, which matches the existing GitHub Actions design

## Rollback

- Revert this PR

## Agent Checklist

- [x] Frontend review completed (`frontend-agent`)
- [x] QA review completed (`qa-agent`)
- [x] Release flow respected (`release-agent`)
- [x] Explicit user approval received for PR creation
- [ ] Explicit user approval received for PR merge
- [x] No direct push to `master`
