### PR TITLE
Fix CSP regression in production stylesheet loading

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,6 +35,11 @@
           "configurations": {
             "production": {
               "deleteOutputPath": true,
+              "optimization": {
+                "styles": {
+                  "inlineCritical": false
+                }
+              },
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
## Summary

- fix the mobile styling regression introduced after merging `#56`
- keep the stricter CSP without breaking Angular production stylesheet loading

## Changes

- disable Angular production `inlineCritical` style inlining in `angular.json`
- ensure the built `index.html` uses a normal stylesheet link instead of `media="print"` plus inline `onload`
- avoid CSP blocking stylesheet activation on mobile and desktop browsers

## Validation

- [x] `npm run build`
- [x] Manual verification done for changed behavior

Manual verification notes:
- compared mobile rendering against the pre-merge PR base commit `15b204b`
- verified the fixed build loads `styles-*.css` via a plain `<link rel="stylesheet">`
- verified corrected mobile rendering in headless Chrome at `390px`

## Risks

- slightly reduces CSS delivery optimization because critical styles are no longer inlined by Angular production build
- preserves the stricter CSP without introducing `unsafe-inline` script execution

## Rollback

- Revert this PR

## Agent Checklist

- [x] Frontend review completed (`frontend-agent`)
- [x] QA review completed (`qa-agent`)
- [x] Release flow respected (`release-agent`)
- [x] Explicit user approval received for PR creation
- [ ] Explicit user approval received for PR merge
- [x] No direct push to `master`
