### PR TITLE
Keep mobile header controls on one row

### DIFF
--- a/src/app/menu/menu.component.css
+++ b/src/app/menu/menu.component.css
@@ -224,16 +224,46 @@
 
 @media (max-width: 480px) {
   .topbar {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
-      'brand'
-      'actions'
-      'links';
+      'brand actions'
+      'links links';
+    padding: 0.78rem 0.82rem;
+    gap: 0.7rem 0.55rem;
+  }
+
+  .brand {
+    min-width: 0;
+    font-size: 0.98rem;
   }
 
   .header-actions {
-    justify-self: stretch;
-    justify-content: space-between;
+    gap: 0.4rem;
+  }
+
+  .controls {
+    gap: 0.35rem;
+  }
+
+  .theme-toggle,
+  .menu-toggle {
+    width: 2.55rem;
+    height: 2.55rem;
+  }
+
+  .theme-toggle {
+    font-size: 1.08rem;
+  }
+
+  .lang-switch {
+    padding: 0.17rem;
+  }
+
+  .lang-switch button {
+    min-width: 2.85rem;
+    min-height: 2.2rem;
+    padding: 0.38rem 0.58rem;
+    font-size: 0.8rem;
   }
 
   .links {


### PR DESCRIPTION
## Summary

- keep the `pirahouski` brand and mobile controls in a single row on narrow screens
- reduce control sizing slightly so the theme, language, and menu buttons fit cleanly without wrapping

## Changes

- removed the extra mobile breakpoint layout that stacked `brand`, `actions`, and `links` into separate rows on screens `<= 480px`
- tightened spacing and sizing for the theme toggle, language switch, and menu button in the smallest viewport range
- preserved the existing mobile navigation drawer behavior

## Validation

- [x] `npm run build`
- [x] Manual verification done for changed behavior

Manual verification notes:
- verified mobile rendering in headless Chrome at `390px`
- confirmed the header now keeps the brand and controls on one row

## Risks

- `menu.component.css` budget warning increases slightly because of the extra responsive rules, but build still passes

## Rollback

- Revert this PR

## Agent Checklist

- [x] Frontend review completed (`frontend-agent`)
- [x] QA review completed (`qa-agent`)
- [x] Release flow respected (`release-agent`)
- [x] Explicit user approval received for PR creation
- [ ] Explicit user approval received for PR merge
- [x] No direct push to `master`
